### PR TITLE
Fix 404 and wrong link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -17,26 +17,26 @@ Satellite IM offers several advantages that make it a promising platform for sec
 
 ## Enhanced Privacy and Security
 
-- **End-to-End Encryption**: Satellite IM uses end-to-end encryption, ensuring that only the intended recipients can read the messages. This protects user data from potential breaches and unauthorized access [source](https://www.businesswire.com/news/home/20220607005114/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures) [source](https://cryptonews.net/news/blockchain/22562181/).
-- **Decentralization**: The platform operates on a decentralized network, meaning that it doesn't rely on central servers that could be targeted for attacks. Instead, data is distributed across a network of nodes, enhancing security and reducing the risk of data breaches [source](https://cryptonews.net/news/blockchain/22562181/).
+- **End-to-End Encryption**: Satellite IM uses end-to-end encryption, ensuring that only the intended recipients can read the messages. This protects user data from potential breaches and unauthorized access [source](https://www.businesswire.com/news/home/20220811005068/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures).
+- **Decentralization**: The platform operates on a decentralized network, meaning that it doesn't rely on central servers that could be targeted for attacks. Instead, data is distributed across a network of nodes, enhancing security and reducing the risk of data breaches.
 
 ## User Data Ownership
 
-- **No Data Tracking**: Unlike traditional messaging platforms, Satellite IM does not track or store user data. This approach respects user privacy and eliminates concerns over data being sold or misused by third parties [source](https://cryptonews.net/news/blockchain/22562181/) [source](https://cryptonews.net/news/blockchain/22562181/).
-- **Sovereign Storage**: Users have full control over their data, which is stored using the Interplanetary File System (IPFS). This means users retain ownership and control over their files and communications [source](https://cryptonews.net/news/blockchain/22562181/).
+- **No Data Tracking**: Unlike traditional messaging platforms, Satellite IM does not track or store user data. This approach respects user privacy and eliminates concerns over data being sold or misused by third parties.
+- **Sovereign Storage**: Users have full control over their data, which is stored using the Interplanetary File System (IPFS). This means users retain ownership and control over their files and communications.
 
 ## High-Quality Communication
 
-- **4K Video and Lossless Audio**: Satellite IM supports high-definition video and audio communications, providing a superior quality experience for users [source](https://www.businesswire.com/news/home/20220607005114/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures) [source](https://cryptonews.net/news/blockchain/22562181/).
-- **Large File Sharing**: The platform allows users to share files up to 10GB, making it convenient for transferring large documents, media files, and other data without compression or quality loss [source](https://www.businesswire.com/news/home/20220607005114/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures).
+- **4K Video and Lossless Audio**: Satellite IM supports high-definition video and audio communications, providing a superior quality experience for users [source](https://www.businesswire.com/news/home/20220811005068/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures)
+- **Large File Sharing**: The platform allows users to share files up to 10GB, making it convenient for transferring large documents, media files, and other data without compression or quality loss [source](https://www.businesswire.com/news/home/20220811005068/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures).
 
 ## Flexibility and Customization
 
-- **Open-Source Platform**: Satellite IM's code is open-source, allowing developers to build and customize applications on top of it. This encourages innovation and continuous improvement of the platform by the community [source](https://cryptonews.net/news/blockchain/22562181/) [source](https://www.businesswire.com/news/home/20220607005114/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures).
-- **Developer-Friendly**: The modular framework and compatibility with multiple blockchain networks make it easy for developers to integrate new features and enhance the platform's functionality [source](https://cryptonews.net/news/blockchain/22562181/) [source](https://cryptonews.net/news/blockchain/22562181/).
+- **Open-Source Platform**: Satellite IM's code is open-source, allowing developers to build and customize applications on top of it. This encourages innovation and continuous improvement of the platform by the community [source](https://www.businesswire.com/news/home/20220811005068/en/Decentralized-Communication-Platform-Satellite-IM-Completes-10.5-Million-Seed-Funding-Led-By-Multicoin-Venture-Fund-Framework-Ventures).
+- **Developer-Friendly**: The modular framework and compatibility with multiple blockchain networks make it easy for developers to integrate new features and enhance the platform's functionality.
 
 ## Community and Ecosystem
 
-- **Focused on Crypto Communities**: Satellite IM is designed to cater to the needs of crypto communities by offering crypto-native features and a decentralized backend. This focus helps it serve a specific user base more effectively than general-purpose messaging platforms like Discord [source](https://cryptonews.net/news/blockchain/22562181/) [source](https://cryptonews.net/news/blockchain/22562181/).
+- **Focused on Crypto Communities**: Satellite IM is designed to cater to the needs of crypto communities by offering crypto-native features and a decentralized backend. This focus helps it serve a specific user base more effectively than general-purpose messaging platforms like Discord.
 
 Overall, Satellite IM's combination of privacy, security, high-quality communication, flexibility, and community focus makes it a compelling choice for users seeking a secure and decentralized messaging platform.


### PR DESCRIPTION
Removes https://cryptonews.net/news/blockchain/22562181 because returns 404

<img width="956" alt="Captura de ecrã 2024-08-18, às 22 50 36" src="https://github.com/user-attachments/assets/4ba7c896-aac5-489c-9bc1-e101a258527e">


Updates the funding url because was going to 

<img width="1101" alt="Captura de ecrã 2024-08-18, às 22 51 11" src="https://github.com/user-attachments/assets/fd964a4b-6137-4585-b783-bac55a861930">

instead of

<img width="1155" alt="Captura de ecrã 2024-08-18, às 22 51 25" src="https://github.com/user-attachments/assets/aa0935fc-944a-4325-925e-2a9970824e24">

